### PR TITLE
feat: support new atrust rvpn

### DIFF
--- a/Clash/ZJU-Rule.list
+++ b/Clash/ZJU-Rule.list
@@ -1,8 +1,13 @@
 # RVPN
 DOMAIN-SUFFIX,rvpn.zju.edu.cn
 DOMAIN-SUFFIX,webvpn.zju.edu.cn
+DOMAIN-SUFFIX,vpn.zju.edu.cn
 
 IP-CIDR,210.32.174.2/32,no-resolve
 IP-CIDR,61.175.193.50/32,no-resolve
 IP-CIDR,124.160.105.200/32,no-resolve
 IP-CIDR,218.108.88.254/32,no-resolve
+IP-CIDR,210.32.129.102/32,no-resolve
+IP-CIDR,210.32.174.64/32,no-resolve
+IP-CIDR,10.3.9.92/31,no-resolve
+IP-CIDR,10.3.9.94/32,no-resolve

--- a/Clash/ZJU-Rule.list
+++ b/Clash/ZJU-Rule.list
@@ -9,5 +9,6 @@ IP-CIDR,124.160.105.200/32,no-resolve
 IP-CIDR,218.108.88.254/32,no-resolve
 IP-CIDR,210.32.129.102/32,no-resolve
 IP-CIDR,210.32.174.64/32,no-resolve
+IP-CIDR,210.32.3.87/32,no-resolve
 IP-CIDR,10.3.9.92/31,no-resolve
 IP-CIDR,10.3.9.94/32,no-resolve


### PR DESCRIPTION
原来的 RVPN (Easy Connect) 在五月份开始关了很多端口，推荐的返校 VPN 更新到了同为深信服的另一款软件 aTrust 上，https://github.com/docker-easyconnect/docker-easyconnect 的 docker-atrust 可以在 docker 中运行 atrust 并提供 socks5/http 代理服务供代理软件使用，与 zjuconnect 的 docker 形式用法差不多。测试下来发现一些域名或 ip 需要直连，这个 PR 添加了这些绕过规则。